### PR TITLE
Fix italic so it stands out when not linked

### DIFF
--- a/lib/jats/italic/_index.css
+++ b/lib/jats/italic/_index.css
@@ -1,3 +1,11 @@
 .sc-italic {
   font-style: italic;
 }
+
+.sc-paragraph .sc-italic {
+  color: #6c757d;
+}
+
+.sc-ext-link .sc-italic {
+  color: #007bff;
+}

--- a/lib/jats/italic/_index.css
+++ b/lib/jats/italic/_index.css
@@ -3,7 +3,7 @@
 }
 
 .sc-paragraph .sc-italic {
-  color: #6c757d;
+  color: lightcoral;
 }
 
 .sc-ext-link .sc-italic {


### PR DESCRIPTION
Changed the CSS so italic is in grey. Let me know if this is enough highlighting or if it should be a different color.
![texture_italic](https://user-images.githubusercontent.com/2396480/51058644-4b120900-159e-11e9-9e67-b71e65ad4894.png)
