### PR TITLE
fix so only words in italic get linked

### DIFF
--- a/examples/Pubv1.html
+++ b/examples/Pubv1.html
@@ -88,9 +88,9 @@
             let terms = eventData.terms;
             console.log("Action: " + action);
 //            console.log("Terms: " + terms);
-
             if(action=="linkPub"){
-                this.markupApp.searchWords(terms);
+				
+                this.markupApp.searchWords(terms, eventData.linkItalics);
         	} else if(action=="navigate") {
 				
 				window.app.childNodes[0].send('tocEntrySelected', terms.path);

--- a/lib/dmc/MarkupApp.js
+++ b/lib/dmc/MarkupApp.js
@@ -139,7 +139,7 @@ class MarkupApp {
         if (callback) callback();
     }
 
-    searchWords(termData, callback) {
+    searchWords(termData, linkItalics, callback) {
         // alert('searching with hits : '+termData.length);
         // alert('searching with hits : '+JSON.stringify(termData));
         console.log('searching with hits: ' + termData.length);
@@ -231,7 +231,7 @@ class MarkupApp {
 				
 				for(let entityMatch in entityMatches) {
 						let entity = entityMatches[entityMatch]
-						if(!((entity.path[0] + ":" + entity.startOffset) in italicNodes) &&
+						if(linkItalics && !((entity.path[0] + ":" + entity.startOffset) in italicNodes) &&
 							!((entity.path[0] + ":" + entity.endOffset) in italicNodes)
 						) {
 							console.log("Not linking " + entity.term.value + " because it isn't in italics")

--- a/lib/dmc/MarkupApp.js
+++ b/lib/dmc/MarkupApp.js
@@ -158,20 +158,19 @@ class MarkupApp {
 
 		let subscriptNodes = [];
 		let superscriptNodes = [];
+		let italicNodes = {};
 		let entityMatches = [];
+
 
 		for (let node in nodes) {
 			if(node.startsWith('subscript')) {
-				subscriptNodes.push(nodes[node]);0
+				subscriptNodes.push(nodes[node]);
 			} else if (node.startsWith('superscript')) {
 				superscriptNodes.push(nodes[node]);
 				let paragraph = window.doc.get(nodes[node].path[0]);
 				console.log("superscript 1 " + paragraph.content.substring(nodes[node].startOffset, nodes[node].endOffset))
 				console.log("superscript 2 " + paragraph.content.substring(paragraph.content.substring(0, nodes[node].startOffset).lastIndexOf(' ') + 1, nodes[node].startOffset))
 				for(let w in termData) {
-//					console.log(termData[w])
-//					console.log(paragraph.content.substring(nodes[node].startOffset, nodes[node].endOffset))
-//					console.log(paragraph.content.substring(paragraph.content.substring(0, nodes[node].startOffset).lastIndexOf(' ') + 1, nodes[node].startOffset))
 				   // Handle the superscript	
 					if(paragraph.content.substring(nodes[node].startOffset, nodes[node].endOffset) == termData[w].value) {
 						entityMatches.push({path: nodes[node].path, startOffset: nodes[node].startOffset, endOffset: nodes[node].endOffset, term: termData[w], type: "superscript"});
@@ -181,6 +180,10 @@ class MarkupApp {
 						entityMatches.push({path: [paragraph.id, 'content'], startOffset: nodes[node].startOffset - termData[w].value.length, endOffset: nodes[node].startOffset, term: termData[w], type: "basesup"})
 					}
 				}
+			} else if(node.startsWith('italic')) {
+				let italic = nodes[node]
+				italicNodes[italic.path[0] + ":" + italic.startOffset] = italic
+				italicNodes[italic.path[0] + ":" + italic.endOffset] = italic
 			}
 
 		}
@@ -227,6 +230,14 @@ class MarkupApp {
 				}
 				
 				for(let entityMatch in entityMatches) {
+						let entity = entityMatches[entityMatch]
+						if(!((entity.path[0] + ":" + entity.startOffset) in italicNodes) &&
+							!((entity.path[0] + ":" + entity.endOffset) in italicNodes)
+						) {
+							console.log("Not linking " + entity.term.value + " because it isn't in italics")
+							continue
+						} 
+						
 						let term = entityMatches[entityMatch].term;
 						let startOffset = entityMatches[entityMatch].startOffset
 						let endOffset = entityMatches[entityMatch].endOffset


### PR DESCRIPTION
Only link words that are in italics. Seems to be working, but it will need some testing to make sure I am catching everything. Also, I can add a option (like a checkbox) if the old behavior is desirable for lexica that isn't in italics.